### PR TITLE
Deployinstructions

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -14,6 +14,7 @@ After ensuring that your directory is accessible, run the configuration script a
 * name for nginx config file: `nginx.conf`
 * directory for www directory: `/var/www` 
 * uwsgi configuration location: `/etc/uwsgi/apps-enabled`
+* number of uwsgi worker processes: `8`
 * uid of service user: `www-data`
 * gid of service usergroup: `www-data`
 * directory of project accessible by your service worker: The location of your repository clone, the recommended path is `/usr/share/eula-aat`

--- a/config.default/eula-aat_uwsgi.ini
+++ b/config.default/eula-aat_uwsgi.ini
@@ -8,6 +8,9 @@ plugin = http
 uid = @SERVICEUSER@
 gid = @SERVICEGROUP@
 
+# Set number of workers
+workers = @UWSGIWORKERS@
+
 # Application's base folder
 base = @CONTENTROOT@/eula-aat
 


### PR DESCRIPTION
I added an option to set the number of uwsgi workers.  Previously only one worker would be started, meaning only one eula could be (quickly) analyzed at the same time.  Might need some tinkering to find out the perfect number for a t2 or c2 medium.